### PR TITLE
Harden optional DL backends, add S3 artifact manifest and safe publishing

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -6,3 +6,12 @@ CURRENT_WEEK=10
 TOP_K_AT_RISK=50
 VALUE_PER_PASS=1200
 INTERVENTION_COST=150
+
+# Model backend: sklearn (default), pytorch, tensorflow
+MODEL_BACKEND=sklearn
+
+# Artifact storage backend: local (default), s3
+STORAGE_BACKEND=local
+AWS_REGION=us-east-1
+S3_BUCKET=
+S3_PREFIX=oulad-artifacts

--- a/requirements-pt.txt
+++ b/requirements-pt.txt
@@ -1,0 +1,3 @@
+-r requirements.txt
+
+torch>=2.1.0

--- a/requirements-tf.txt
+++ b/requirements-tf.txt
@@ -1,0 +1,3 @@
+-r requirements.txt
+
+tensorflow>=2.13.0

--- a/requirements.txt
+++ b/requirements.txt
@@ -18,3 +18,6 @@ psycopg2-binary>=2.9.0
 
 # Additional utilities
 scipy>=1.7.0
+
+# Optional cloud artifact publishing
+boto3>=1.28.0

--- a/src/config.py
+++ b/src/config.py
@@ -29,6 +29,11 @@ class PipelineConfig:
     value_per_pass: float
     default_intervention_cost: float
     demo_mode: bool
+    model_backend: str
+    storage_backend: str
+    aws_region: str
+    s3_bucket: str
+    s3_prefix: str
 
 
 def _env_float(name: str, default: float) -> float:
@@ -67,6 +72,11 @@ def load_config(demo_mode: bool | None = None) -> PipelineConfig:
         value_per_pass=_env_float("VALUE_PER_PASS", 1200.0),
         default_intervention_cost=_env_float("INTERVENTION_COST", 150.0),
         demo_mode=use_demo_mode,
+        model_backend=os.getenv("MODEL_BACKEND", "sklearn").strip().lower(),
+        storage_backend=os.getenv("STORAGE_BACKEND", "local").strip().lower(),
+        aws_region=os.getenv("AWS_REGION", "us-east-1"),
+        s3_bucket=os.getenv("S3_BUCKET", "").strip(),
+        s3_prefix=os.getenv("S3_PREFIX", "").strip("/"),
     )
 
 

--- a/src/model/evaluate.py
+++ b/src/model/evaluate.py
@@ -10,7 +10,13 @@ from sklearn.metrics import auc, confusion_matrix, precision_recall_curve, roc_a
 from src.config import PipelineConfig
 
 
-def evaluate_model(model: object, X_test, y_test, config: PipelineConfig) -> dict:
+def evaluate_model(
+    model: object,
+    X_test,
+    y_test,
+    config: PipelineConfig,
+    backend_hyperparams: dict,
+) -> dict:
     probs = model.predict_proba(X_test)[:, 1]
     preds = (probs >= 0.5).astype(int)
     precision, recall, _ = precision_recall_curve(y_test, probs)
@@ -22,6 +28,8 @@ def evaluate_model(model: object, X_test, y_test, config: PipelineConfig) -> dic
         ),
         "recall_at_0_5": float(np.sum((preds == 1) & (y_test == 1)) / max(np.sum(y_test == 1), 1)),
         "confusion_matrix": confusion_matrix(y_test, preds).tolist(),
+        "model_backend": config.model_backend,
+        "backend_hyperparams": backend_hyperparams,
     }
     (config.outputs_dir / "metrics_latest.json").write_text(json.dumps(metrics, indent=2))
     return metrics

--- a/src/model/explain.py
+++ b/src/model/explain.py
@@ -1,4 +1,4 @@
-"""SHAP explainability output generation."""
+"""Explainability output generation."""
 
 from __future__ import annotations
 
@@ -10,14 +10,22 @@ matplotlib.use("Agg")
 import matplotlib.pyplot as plt
 import pandas as pd
 import shap
+from sklearn.inspection import permutation_importance
 
 from src.config import PipelineConfig
 
 
-def generate_shap_artifacts(model: object, X_train: pd.DataFrame, config: PipelineConfig) -> dict:
+def _generate_shap_top_features(
+    model: object, X_train: pd.DataFrame, config: PipelineConfig
+) -> dict:
     sample = X_train.sample(n=min(200, len(X_train)), random_state=config.random_seed)
-    explainer = shap.Explainer(model, sample)
-    shap_values = explainer(sample)
+    if hasattr(model, "scaler") and hasattr(model, "model"):
+        sample_scaled = pd.DataFrame(model.scaler.transform(sample), columns=sample.columns)
+        explainer = shap.Explainer(model.model, sample_scaled)
+        shap_values = explainer(sample_scaled)
+    else:
+        explainer = shap.Explainer(model, sample)
+        shap_values = explainer(sample)
 
     plt.figure(figsize=(8, 5))
     shap.plots.beeswarm(shap_values, max_display=10, show=False)
@@ -29,7 +37,37 @@ def generate_shap_artifacts(model: object, X_train: pd.DataFrame, config: Pipeli
     mean_abs = pd.Series(abs(shap_values.values).mean(axis=0), index=sample.columns).sort_values(
         ascending=False
     )
-    top_features = mean_abs.head(10).to_dict()
+    return mean_abs.head(10).to_dict()
+
+
+def _generate_permutation_top_features(
+    model: object, X_train: pd.DataFrame, y_train: pd.Series, config: PipelineConfig
+) -> dict:
+    result = permutation_importance(
+        model,
+        X_train,
+        y_train,
+        n_repeats=10,
+        random_state=config.random_seed,
+        scoring="roc_auc",
+    )
+    importances = pd.Series(result.importances_mean, index=X_train.columns).sort_values(
+        ascending=False
+    )
+    return importances.head(10).to_dict()
+
+
+def generate_shap_artifacts(
+    model: object,
+    X_train: pd.DataFrame,
+    y_train: pd.Series,
+    config: PipelineConfig,
+) -> dict:
+    if config.model_backend == "sklearn":
+        top_features = _generate_shap_top_features(model, X_train, config)
+    else:
+        top_features = _generate_permutation_top_features(model, X_train, y_train, config)
+
     out_json = config.outputs_dir / "shap_top_features.json"
     out_json.write_text(json.dumps(top_features, indent=2))
     return top_features

--- a/src/model/train_sklearn.py
+++ b/src/model/train_sklearn.py
@@ -1,0 +1,38 @@
+"""Scikit-learn backend training."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+
+import pandas as pd
+from sklearn.linear_model import LogisticRegression
+from sklearn.preprocessing import StandardScaler
+
+
+@dataclass
+class SklearnRiskModel:
+    model: LogisticRegression
+    scaler: StandardScaler
+
+    def predict_proba(self, X: pd.DataFrame):
+        X_scaled = self.scaler.transform(X)
+        return self.model.predict_proba(X_scaled)
+
+
+def train_sklearn(
+    X_train: pd.DataFrame,
+    y_train: pd.Series,
+    random_seed: int,
+    demo_mode: bool = False,
+):
+    del demo_mode
+    scaler = StandardScaler()
+    X_train_scaled = scaler.fit_transform(X_train)
+    model = LogisticRegression(max_iter=1000, random_state=random_seed)
+    model.fit(X_train_scaled, y_train)
+    params = {
+        "model_type": "LogisticRegression",
+        "max_iter": 1000,
+        "random_seed": random_seed,
+    }
+    return SklearnRiskModel(model=model, scaler=scaler), params

--- a/src/model/train_tf.py
+++ b/src/model/train_tf.py
@@ -1,0 +1,63 @@
+"""TensorFlow backend training."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+
+import numpy as np
+import pandas as pd
+from sklearn.preprocessing import StandardScaler
+
+
+@dataclass
+class TensorFlowRiskModel:
+    model: object
+    scaler: StandardScaler
+
+    def predict_proba(self, X: pd.DataFrame):
+        X_scaled = self.scaler.transform(X)
+        probs = self.model.predict(X_scaled, verbose=0).reshape(-1)
+        return np.column_stack([1 - probs, probs])
+
+
+def train_tf(
+    X_train: pd.DataFrame,
+    y_train: pd.Series,
+    random_seed: int,
+    demo_mode: bool = False,
+):
+    import tensorflow as tf
+
+    tf.random.set_seed(random_seed)
+    np.random.seed(random_seed)
+
+    scaler = StandardScaler()
+    X_train_scaled = scaler.fit_transform(X_train)
+
+    model = tf.keras.Sequential(
+        [
+            tf.keras.layers.Input(shape=(X_train.shape[1],)),
+            tf.keras.layers.Dense(32, activation="relu"),
+            tf.keras.layers.Dropout(0.1),
+            tf.keras.layers.Dense(16, activation="relu"),
+            tf.keras.layers.Dense(1, activation="sigmoid"),
+        ]
+    )
+    model.compile(
+        optimizer=tf.keras.optimizers.Adam(learning_rate=1e-3),
+        loss="binary_crossentropy",
+    )
+    epochs = 3 if demo_mode else 40
+    model.fit(X_train_scaled, y_train.values, epochs=epochs, batch_size=64, verbose=0)
+
+    params = {
+        "model_type": "KerasMLPClassifier",
+        "hidden_layers": [32, 16],
+        "dropout": 0.1,
+        "optimizer": "Adam",
+        "lr": 1e-3,
+        "epochs": epochs,
+        "batch_size": 64,
+        "random_seed": random_seed,
+    }
+    return TensorFlowRiskModel(model=model, scaler=scaler), params

--- a/src/model/train_torch.py
+++ b/src/model/train_torch.py
@@ -1,0 +1,83 @@
+"""PyTorch backend training."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+
+import numpy as np
+import pandas as pd
+from sklearn.preprocessing import StandardScaler
+
+
+@dataclass
+class TorchRiskModel:
+    model: object
+    scaler: StandardScaler
+    torch: object
+
+    def predict_proba(self, X: pd.DataFrame):
+        X_scaled = self.scaler.transform(X).astype(np.float32)
+        self.model.eval()
+        with self.torch.no_grad():
+            logits = self.model(self.torch.tensor(X_scaled))
+            probs = self.torch.sigmoid(logits).cpu().numpy().reshape(-1)
+        return np.column_stack([1 - probs, probs])
+
+
+def train_torch(
+    X_train: pd.DataFrame,
+    y_train: pd.Series,
+    random_seed: int,
+    demo_mode: bool = False,
+):
+    import torch
+    import torch.nn as nn
+
+    torch.manual_seed(random_seed)
+    np.random.seed(random_seed)
+
+    scaler = StandardScaler()
+    X_train_scaled = scaler.fit_transform(X_train).astype(np.float32)
+    y_train_arr = y_train.values.astype(np.float32).reshape(-1, 1)
+
+    class MLP(nn.Module):
+        def __init__(self, in_features: int):
+            super().__init__()
+            self.net = nn.Sequential(
+                nn.Linear(in_features, 32),
+                nn.ReLU(),
+                nn.Dropout(0.1),
+                nn.Linear(32, 16),
+                nn.ReLU(),
+                nn.Linear(16, 1),
+            )
+
+        def forward(self, x):
+            return self.net(x)
+
+    model = MLP(X_train.shape[1])
+    loss_fn = nn.BCEWithLogitsLoss()
+    optimizer = torch.optim.Adam(model.parameters(), lr=1e-3)
+
+    X_tensor = torch.tensor(X_train_scaled)
+    y_tensor = torch.tensor(y_train_arr)
+
+    epochs = 3 if demo_mode else 60
+    model.train()
+    for _ in range(epochs):
+        optimizer.zero_grad()
+        logits = model(X_tensor)
+        loss = loss_fn(logits, y_tensor)
+        loss.backward()
+        optimizer.step()
+
+    params = {
+        "model_type": "TorchMLPClassifier",
+        "hidden_layers": [32, 16],
+        "dropout": 0.1,
+        "optimizer": "Adam",
+        "lr": 1e-3,
+        "epochs": epochs,
+        "random_seed": random_seed,
+    }
+    return TorchRiskModel(model=model, scaler=scaler, torch=torch), params

--- a/tests/test_pipeline_smoke.py
+++ b/tests/test_pipeline_smoke.py
@@ -1,16 +1,23 @@
 """Smoke tests for demo pipeline execution."""
 
+import json
 from pathlib import Path
+
+import pytest
 
 from src.pipeline import run_pipeline
 
 
-def test_demo_pipeline_smoke() -> None:
+@pytest.mark.parametrize("backend", ["sklearn"])
+def test_demo_pipeline_smoke(monkeypatch: pytest.MonkeyPatch, backend: str) -> None:
     """Pipeline should run in demo mode and emit core text artifacts."""
+    monkeypatch.setenv("MODEL_BACKEND", backend)
     run_pipeline(demo_mode=True)
 
     expected_outputs = [
         Path("outputs/metrics_latest.json"),
+        Path("outputs/shap_top_features.json"),
+        Path("outputs/artifacts_manifest.json"),
         Path("outputs/alerts/alert_latest.md"),
         Path("outputs/marts/student_risk_daily_sample.csv"),
         Path("reports/ab_test_report.md"),
@@ -20,3 +27,26 @@ def test_demo_pipeline_smoke() -> None:
 
     missing = [str(path) for path in expected_outputs if not path.exists()]
     assert not missing, f"Missing expected artifacts: {missing}"
+
+    manifest = json.loads(Path("outputs/artifacts_manifest.json").read_text())
+    assert manifest["model_backend"] == "sklearn"
+    assert manifest["db_mode"] in {"sqlite", "postgres"}
+    assert manifest["artifacts"], "Expected manifest artifacts to be non-empty"
+
+
+@pytest.mark.parametrize(
+    "backend,module_name",
+    [("pytorch", "torch"), ("tensorflow", "tensorflow")],
+)
+def test_optional_deep_learning_backends(
+    monkeypatch: pytest.MonkeyPatch,
+    backend: str,
+    module_name: str,
+) -> None:
+    pytest.importorskip(module_name)
+    monkeypatch.setenv("MODEL_BACKEND", backend)
+    run_pipeline(demo_mode=True)
+
+    metrics = json.loads(Path("outputs/metrics_latest.json").read_text())
+    assert metrics["model_backend"] == backend
+    assert metrics["backend_hyperparams"]["epochs"] <= 3


### PR DESCRIPTION
### Motivation
- Keep the default `MODEL_BACKEND` usable (sklearn) while making optional PyTorch/TensorFlow paths robust and non-failing when optional deps are absent.  
- Avoid promising SHAP for DL backends that won't run in many environments and instead provide a reliable explainability fallback.  
- Limit S3 uploads to small, stable artifacts and produce a manifest that serves as audit evidence for every run.  

### Description
- Lazy-loads optional trainers via `_get_backend_trainer` in `src/model/train.py` so `pytorch`/`tensorflow` are imported only when selected and missing deps raise clear guidance (`pip install -r requirements-pt.txt` / `requirements-tf.txt`).  
- Moves DL imports into their trainers (`src/model/train_torch.py`, `src/model/train_tf.py`) and reduces demo-mode epochs to `3` to keep optional smoke runs short; `sklearn` remains the default baseline (`src/model/train_sklearn.py`).  
- Switches explainability to a safe strategy in `src/model/explain.py`: SHAP for the `sklearn` backend and permutation importance for `pytorch`/`tensorflow`, while keeping a stable `outputs/shap_top_features.json` schema and writing a `shap_summary.png` for sklearn.  
- Implements a tighten S3 publishing whitelist and run manifest in `src/pipeline.py` that includes `run_id`, `timestamp`, `model_backend`, `db_mode`, per-file `local_path`, `size_bytes`, and `storage_uri`, and uploads only small artifacts (metrics, shap, marts csv, alerts md, reports md/csv, and the manifest).  
- Adds a boto3-backed `S3Storage` implementation in `src/storage.py` (with `put_text`, `put_file`, `exists`) and keeps `LocalStorage` for local runs, plus new config fields for `MODEL_BACKEND`, `STORAGE_BACKEND`, `AWS_REGION`, `S3_BUCKET`, and `S3_PREFIX` in `src/config.py`.  
- Adds/deploys support files and docs: `requirements-pt.txt`, `requirements-tf.txt`, `requirements.txt` updated with `boto3`, README clarifications for optional DL backends and S3 publishing, and updates `tests/test_pipeline_smoke.py` to assert manifest and to `importorskip` optional DL modules.  

### Testing
- Ran `ruff check src tests` and `black --check src tests`, and both checks passed.  
- Ran the full `make check` (compile + lint + black + pytest) and it completed successfully.  
- Ran `pytest -q` and the smoke tests passed with the optional DL tests skipped when modules are not present (`1 passed, 2 skipped`).  
- Executed `python -m src.pipeline --demo` and the end-to-end demo completed successfully and produced the expected artifacts including `outputs/artifacts_manifest.json`.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_698d8489ba208326ac079091fe4846e1)