### PR TITLE
Postgres-first pipeline run + Power BI onboarding

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,7 +1,7 @@
-.PHONY: run run-demo compile lint format test check docker-up
+.PHONY: run run-demo compile lint format test check docker-up verify-postgres
 
 run:
-	python -m src.pipeline
+	python -m src.pipeline --demo
 
 run-demo:
 	python -m src.pipeline --demo
@@ -24,3 +24,7 @@ check: compile lint test
 
 docker-up:
 	docker compose up --build
+
+verify-postgres:
+	docker compose exec -T postgres psql -U oulad -d oulad_analytics -c "\dt"
+	docker compose exec -T postgres psql -U oulad -d oulad_analytics -c "SELECT 'student_risk_daily' AS table_name, COUNT(*) AS row_count FROM student_risk_daily UNION ALL SELECT 'course_summary_daily', COUNT(*) FROM course_summary_daily UNION ALL SELECT 'experiment_results', COUNT(*) FROM experiment_results UNION ALL SELECT 'alert_log', COUNT(*) FROM alert_log;"

--- a/README.md
+++ b/README.md
@@ -174,11 +174,34 @@ These same checks are wired into `.github/workflows/daily_pipeline.yml`.
 - **BI layer**: marts aligned for Power BI connectivity.
 
 ## How to Run
-### Local (default sklearn backend)
+### Postgres-backed demo flow (recommended)
+1) Start Postgres:
+```bash
+docker compose up -d postgres
+```
+
+2) Install dependencies:
 ```bash
 pip install -r requirements.txt
-python -m src.pipeline --demo
 ```
+
+3) Point the pipeline to Postgres (pipeline falls back to SQLite only when `DATABASE_URL` is unset):
+```bash
+export DATABASE_URL=postgresql://oulad:oulad@localhost:5432/oulad_analytics
+```
+
+4) Run the full demo pipeline and publish marts:
+```bash
+make run
+```
+
+5) Verify tables and row counts:
+```bash
+make verify-postgres
+```
+
+### Local SQLite fallback
+If `DATABASE_URL` is not set, the same `make run` command writes to local SQLite at `data/processed/pipeline.db`.
 
 ### Optional Deep Learning Backends (PyTorch / TensorFlow)
 Sklearn remains the default baseline. PyTorch/TensorFlow are optional and only used when `MODEL_BACKEND` is set explicitly.
@@ -195,11 +218,6 @@ MODEL_BACKEND=tensorflow python -m src.pipeline --demo
 
 PyTorch installation may vary by OS/CUDA; if needed, use the official PyTorch install command for your platform.
 
-### Docker
-```bash
-docker compose up --build
-```
-
 ### Optional environment variables
 - `DATABASE_URL`
 - `PIPELINE_DEMO_MODE=true|false`
@@ -211,6 +229,19 @@ docker compose up --build
 - `AWS_REGION=us-east-1`
 - `S3_BUCKET=<your-bucket>`
 - `S3_PREFIX=oulad-artifacts`
+
+## Power BI: Connect to Postgres
+1) In Power BI Desktop, select **Get Data** → **PostgreSQL database**.
+2) Server: `localhost`.
+3) Database: `oulad_analytics`.
+4) Credentials: username `oulad`, password `oulad`.
+5) Choose **Import** mode for quickest demo setup.
+6) Select these tables:
+   - `student_risk_daily`
+   - `course_summary_daily`
+   - `experiment_results`
+   - `alert_log`
+7) Click **Load** and build visuals (examples: risk trend by `run_date`, module heatmap by `high_risk_rate`, alert timeline by `run_ts`).
 
 ### S3 Artifact Publishing
 Set these env vars: `STORAGE_BACKEND`, `AWS_REGION`, `S3_BUCKET`, `S3_PREFIX`.

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -10,6 +10,11 @@ services:
       - "5432:5432"
     volumes:
       - pgdata:/var/lib/postgresql/data
+    healthcheck:
+      test: ["CMD-SHELL", "pg_isready -U oulad -d oulad_analytics"]
+      interval: 5s
+      timeout: 5s
+      retries: 10
 
   app:
     build:
@@ -19,7 +24,7 @@ services:
     depends_on:
       - postgres
     environment:
-      DATABASE_URL: postgresql+psycopg2://oulad:oulad@postgres:5432/oulad_analytics
+      DATABASE_URL: postgresql://oulad:oulad@postgres:5432/oulad_analytics
       PIPELINE_DEMO_MODE: "true"
       HIGH_RISK_THRESHOLD: "0.25"
       RISK_SPIKE_THRESHOLD_PCT: "0.10"

--- a/src/config.py
+++ b/src/config.py
@@ -20,6 +20,7 @@ class PipelineConfig:
     models_dir: Path
     db_path: Path
     database_url: str | None
+    db_mode: str
     random_seed: int
     high_risk_threshold: float
     spike_threshold_pct: float
@@ -51,6 +52,7 @@ def load_config(demo_mode: bool | None = None) -> PipelineConfig:
         if demo_mode is None
         else demo_mode
     )
+    database_url = os.getenv("DATABASE_URL")
     return PipelineConfig(
         repo_root=root,
         data_raw_dir=root / "data" / "raw",
@@ -62,7 +64,8 @@ def load_config(demo_mode: bool | None = None) -> PipelineConfig:
         reports_dir=root / "reports",
         models_dir=root / "models",
         db_path=root / "data" / "processed" / "pipeline.db",
-        database_url=os.getenv("DATABASE_URL"),
+        database_url=database_url,
+        db_mode="postgres" if database_url else "sqlite",
         random_seed=_env_int("PIPELINE_RANDOM_SEED", 42),
         high_risk_threshold=_env_float("HIGH_RISK_THRESHOLD", 0.25),
         spike_threshold_pct=_env_float("RISK_SPIKE_THRESHOLD_PCT", 0.10),


### PR DESCRIPTION
### Motivation
- Make the pipeline prefer Postgres when `DATABASE_URL` is set and provide an end-to-end demo flow that publishes BI marts into Postgres for Power BI consumption.
- Provide clear local runbook steps and a verification target so reviewers can start Postgres, run the pipeline, and confirm marts/logs exist.

### Description
- Config: added `db_mode` to `PipelineConfig` and set it to `postgres` when `DATABASE_URL` is present and `sqlite` otherwise in `src/config.py`.
- DB client: updated `src/etl/load.py` to always prefer Postgres when `DATABASE_URL` exists (normalize `postgresql+psycopg2://` to `postgresql://` for direct `psycopg2` connection) and improved `insert_df` to use `itertuples` for reliable value tuples.
- Docker/Make: updated `docker-compose.yml` with a Postgres healthcheck and aligned the app `DATABASE_URL`, changed `Makefile` so `make run` runs the demo pipeline and added `make verify-postgres` to list tables and row counts.
- Docs: added a Postgres-backed runbook and a new "Power BI: Connect to Postgres" section in `README.md` with exact connection details and the list of tables to import (`student_risk_daily`, `course_summary_daily`, `experiment_results`, `alert_log`).

### Testing
- Ran the full demo pipeline via `make run` which completed successfully and produced marts (pipeline logged completion). 
- Ran `python -m compileall src && pytest -q` which compiled sources and ran tests producing `1 passed, 2 skipped`.
- Ran lint via `make lint` which completed with all checks passing.
- Performed an automated SQLite verification (fallback run in this environment) that counted rows in the required tables and returned non-zero counts: `student_risk_daily=600`, `course_summary_daily=8`, `experiment_results=6`, `alert_log=2`.
- `docker compose up -d postgres` / `make verify-postgres` were attempted but failed in this runner because the `docker` CLI is not available here (this verification works locally where Docker is present).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69910dfdb8088326a170245ffd9ce905)